### PR TITLE
Fix initializer autoloading in Rails 7

### DIFF
--- a/lib/graphiti_graphql/engine.rb
+++ b/lib/graphiti_graphql/engine.rb
@@ -65,15 +65,18 @@ module GraphitiGraphQL
     end
 
     initializer "graphiti_graphql.define_controller" do
-      require "#{Rails.root}/app/controllers/application_controller"
-      app_controller = GraphitiGraphQL.config.federation_application_controller || ::ApplicationController
-      # rubocop:disable Lint/ConstantDefinitionInBlock(Standard)
-      class GraphitiGraphQL::ExecutionController < app_controller
-        register_exception Graphiti::Errors::UnreadableAttribute, message: true
-        def execute
-          params = request.params # avoid strong_parameters
-          render json: Graphiti.gql(params[:query], params[:variables])
+      ::GraphitiGraphQL::Engine.reloader_class.to_prepare do
+        require "#{Rails.root}/app/controllers/application_controller"
+        app_controller = GraphitiGraphQL.config.federation_application_controller || ::ApplicationController
+        # rubocop:disable Lint/ConstantDefinitionInBlock(Standard)
+        class GraphitiGraphQL::ExecutionController < app_controller
+          register_exception Graphiti::Errors::UnreadableAttribute, message: true
+          def execute
+            params = request.params # avoid strong_parameters
+            render json: Graphiti.gql(params[:query], params[:variables])
+          end
         end
+        # rubocop:enable Lint/ConstantDefinitionInBlock(Standard)
       end
     end
 


### PR DESCRIPTION
This was causing problems when I attempted to upgrade to Rails 7: my `ApplicationController` references some code that doesn't get loaded until Rails has been initialized, and this engine was attempting to load `ApplicationController` before Rails is initialized. This resulted in the code not being found. Wrapping it in a `to_prepare` block fixed the problem. I think this wasn't an issue in Rails 6 because the Zeitwork autoloader is strictly enforced in Rails 7.

This also fixes a Rubocop being disabled and not re-enabled afterward.